### PR TITLE
👾  Fix thread execution for setting wallpaper

### DIFF
--- a/android/src/main/java/com/cunyutech/hollyliu/reactnative/wallpaper/WallPaperManager.java
+++ b/android/src/main/java/com/cunyutech/hollyliu/reactnative/wallpaper/WallPaperManager.java
@@ -238,6 +238,8 @@ public class WallPaperManager extends ReactContextBaseJavaModule {
                     return true;
                   }
                 }.execute(bitmap);
+
+                return;
             }
 
             @Override

--- a/android/src/main/java/com/cunyutech/hollyliu/reactnative/wallpaper/WallPaperManager.java
+++ b/android/src/main/java/com/cunyutech/hollyliu/reactnative/wallpaper/WallPaperManager.java
@@ -11,6 +11,7 @@ import android.graphics.PixelFormat;
 import android.app.Activity;
 import android.app.WallpaperManager;
 import android.graphics.BitmapFactory;
+import android.os.AsyncTask;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.model.GlideUrl;
@@ -223,16 +224,20 @@ public class WallPaperManager extends ReactContextBaseJavaModule {
             @Override
             public void onResourceReady(byte[] resource, GlideAnimation<? super byte[]> glideAnimation) {
                 Bitmap bitmap = BitmapFactory.decodeByteArray(resource, 0, resource.length);
-                try
-                {
-                    wallpaperManager.setBitmap(bitmap);
-                    sendMessage("success","Set Wallpaper Success",source);
-                }
-                catch (Exception e)
-                {
-                    sendMessage("error","Exception in SimpleTarget：" + e.getMessage(),source);
-                    return;
-                }
+
+                new AsyncTask<Bitmap, Void, Boolean>() {
+                  @Override
+                  protected Boolean doInBackground(Bitmap... bmps) {
+                    try {
+                      wallpaperManager.setBitmap(bmps[0]);
+                      sendMessage("success", "Set Wallpaper Success", source);
+                    } catch (Exception e) {
+                      sendMessage("error", "Exception in SimpleTarget：" + e.getMessage(), source);
+                      return false;
+                    }
+                    return true;
+                  }
+                }.execute(bitmap);
             }
 
             @Override


### PR DESCRIPTION
We were getting ANR (app not responding) error reports that straced to
`wallpaperManager.setBitmap`.

The Glide stuff needed to be run on the main thread in order to process
and animate the image (I think?), so the solution to this seemed to be
that the `setBitmap` call should be executed in a background thread.
This is possible by using `AsyncTask`.

This seems to work fine in the simulator so 🤞